### PR TITLE
Add FastAPI webhook entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # orchestra.ai
- A conversational AI orchestration platform for automating business voice communications
+A conversational AI orchestration platform for automating business voice communications.
+
+## Orchestration Webhook
+A FastAPI app is provided in `src/orchestra/app.py` with a `/webhook` endpoint. It wires together the `VoiceServer` and `Orchestrator` classes and logs each interaction, completing an audio/text round-trip.
+
+Run the service locally:
+
+```bash
+uvicorn orchestra.app:app --host 0.0.0.0 --port 8000
+```
+
+Build and run with Docker:
+
+```bash
+docker build -f docker/Dockerfile.orchestration -t orchestration .
+docker run -p 8000:8000 orchestration
+```

--- a/docker/Dockerfile.orchestration
+++ b/docker/Dockerfile.orchestration
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+COPY knowledge_base ./knowledge_base
+
+ENV PYTHONPATH=/app/src
+
+CMD ["uvicorn", "orchestra.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/orchestra/__init__.py
+++ b/src/orchestra/__init__.py
@@ -1,0 +1,1 @@
+"""orchestra package initialization."""

--- a/src/orchestra/app.py
+++ b/src/orchestra/app.py
@@ -1,0 +1,33 @@
+"""FastAPI application for orchestration webhook."""
+from fastapi import FastAPI, Request
+
+# These imports rely on existing modules within the project.
+# They are expected to provide the audio/text orchestration utilities.
+from .voice_server import VoiceServer
+from .orchestrator import Orchestrator
+from .logging import log_interaction
+
+app = FastAPI()
+
+@app.post("/webhook")
+async def webhook(request: Request):
+    """Handle audio/text round-trips via the orchestration pipeline."""
+    payload = await request.json()
+
+    voice_server = VoiceServer()
+    orchestrator = Orchestrator()
+
+    # If text isn't provided, attempt to transcribe from audio input
+    user_text = payload.get("text")
+    if not user_text and "audio" in payload:
+        user_text = await voice_server.transcribe(payload["audio"])
+
+    # Generate a response from the orchestrator
+    response_text = await orchestrator.respond(user_text)
+
+    # Log the interaction for auditing/analytics
+    await log_interaction(user_text, response_text)
+
+    # Return synthesized audio along with text response
+    audio_payload = await voice_server.synthesize(response_text)
+    return {"text": response_text, "audio": audio_payload}


### PR DESCRIPTION
## Summary
- add `src/orchestra/app.py` with `/webhook` FastAPI endpoint orchestrating audio/text round-trips
- document running the webhook and provide orchestration Dockerfile

## Testing
- `python -m py_compile src/orchestra/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f91be9608832388fc10c6f204a46f