### PR TITLE
Expose orchestration modules

### DIFF
--- a/src/orchestra/orchestration/__init__.py
+++ b/src/orchestra/orchestration/__init__.py
@@ -1,1 +1,12 @@
-"""Orchestration layer for Orchestra.ai"""
+"""Orchestration layer for Orchestra.ai.
+
+This package exposes the available orchestrator implementations used by
+Orchestra.  Additional orchestrators can be registered here as they are
+implemented.
+"""
+
+from .langgraph_orchestrator import LangGraphOrchestrator
+from .autogen_orchestrator import AutoGenOrchestrator
+
+__all__ = ["LangGraphOrchestrator", "AutoGenOrchestrator"]
+

--- a/src/orchestra/orchestration/agents/__init__.py
+++ b/src/orchestra/orchestration/agents/__init__.py
@@ -1,1 +1,6 @@
-# Agents package
+"""Agent implementations used by the orchestration layer."""
+
+from .parser_agent import ParserAgent
+
+__all__ = ["ParserAgent"]
+

--- a/src/orchestra/orchestration/chains/__init__.py
+++ b/src/orchestra/orchestration/chains/__init__.py
@@ -1,1 +1,6 @@
-# Chains package
+"""Chain implementations used by the orchestration layer."""
+
+from .retrieval_chain import RetrievalChain
+
+__all__ = ["RetrievalChain"]
+


### PR DESCRIPTION
## Summary
- expose available orchestrators at the package level
- provide explicit exports for agent and chain modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc303eee08323930037aedcaa4f80