### PR TITLE
Expose orchestration modules and centralize tool execution

### DIFF
--- a/src/orchestra/execution/__init__.py
+++ b/src/orchestra/execution/__init__.py
@@ -1,1 +1,5 @@
-"""Execution layer for Orchestra.ai"""
+"""Execution layer for Orchestra.ai."""
+
+from .tool_executor import ToolExecutor
+
+__all__ = ["ToolExecutor"]

--- a/src/orchestra/execution/tool_executor.py
+++ b/src/orchestra/execution/tool_executor.py
@@ -1,26 +1,21 @@
 import asyncio
 from typing import Dict, Any, List, Callable
+
 from ..interfaces import ToolInterface
+from . import tools
 
 
 class ToolExecutor(ToolInterface):
-    """Central tool execution coordinator"""
+    """Central tool execution coordinator."""
 
     def __init__(self):
         self.registered_tools: Dict[str, Callable] = {}
         self._register_default_tools()
 
-    def _register_default_tools(self):
-        """Register default tools"""
-        from .tools.menu import get_menu, search_menu_item, get_business_hours
-        from .tools.sheets import add_order_to_sheet
-
-        self.registered_tools.update({
-            "get_menu": get_menu,
-            "search_menu_item": search_menu_item,
-            "get_business_hours": get_business_hours,
-            "add_order_to_sheet": add_order_to_sheet
-        })
+    def _register_default_tools(self) -> None:
+        """Register all tools exposed by the tools package."""
+        for name in getattr(tools, "__all__", []):
+            self.registered_tools[name] = getattr(tools, name)
 
     async def execute(self, tool_name: str, parameters: Dict[str, Any]) -> Dict[str, Any]:
         """Execute a tool with given parameters"""

--- a/src/orchestra/execution/tools/__init__.py
+++ b/src/orchestra/execution/tools/__init__.py
@@ -1,6 +1,16 @@
-"""
-Orchestra.ai Tool Registry
+"""Orchestra.ai Tool Registry.
 
 This module contains all tools available to the AI agents.
 Tools are functions that agents can call to interact with external systems.
 """
+
+from .menu import get_menu, search_menu_item, get_business_hours
+from .sheets import add_order_to_sheet, check_inventory
+
+__all__ = [
+    "get_menu",
+    "search_menu_item",
+    "get_business_hours",
+    "add_order_to_sheet",
+    "check_inventory",
+]

--- a/src/orchestra/orchestration/__init__.py
+++ b/src/orchestra/orchestration/__init__.py
@@ -1,1 +1,12 @@
-"""Orchestration layer for Orchestra.ai"""
+"""Orchestration layer for Orchestra.ai.
+
+This package exposes the available orchestrator implementations used by
+Orchestra.  Additional orchestrators can be registered here as they are
+implemented.
+"""
+
+from .langgraph_orchestrator import LangGraphOrchestrator
+from .autogen_orchestrator import AutoGenOrchestrator
+
+__all__ = ["LangGraphOrchestrator", "AutoGenOrchestrator"]
+

--- a/src/orchestra/orchestration/agents/__init__.py
+++ b/src/orchestra/orchestration/agents/__init__.py
@@ -1,1 +1,6 @@
-# Agents package
+"""Agent implementations used by the orchestration layer."""
+
+from .parser_agent import ParserAgent
+
+__all__ = ["ParserAgent"]
+

--- a/src/orchestra/orchestration/chains/__init__.py
+++ b/src/orchestra/orchestration/chains/__init__.py
@@ -1,1 +1,6 @@
-# Chains package
+"""Chain implementations used by the orchestration layer."""
+
+from .retrieval_chain import RetrievalChain
+
+__all__ = ["RetrievalChain"]
+


### PR DESCRIPTION
## Summary
- expose available orchestrators at the package level
- provide explicit exports for agent and chain modules
- centralize tool execution by auto-registering tools from the tools package

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fc303eee08323930037aedcaa4f80