### PR TITLE
Introduce knowledge layer interface for menu data

### DIFF
--- a/src/orchestra/interfaces.py
+++ b/src/orchestra/interfaces.py
@@ -50,3 +50,10 @@ class PersistenceInterface(ABC):
     @abstractmethod
     async def save_state(self, state: ConversationState) -> None:
         pass
+
+
+class KnowledgeInterface(ABC):
+    @abstractmethod
+    def load_menu(self) -> Dict[str, Any]:
+        """Retrieve the restaurant menu or other knowledge sources."""
+        pass

--- a/src/orchestra/knowledge/__init__.py
+++ b/src/orchestra/knowledge/__init__.py
@@ -1,0 +1,5 @@
+"""Knowledge layer with centralized data access utilities."""
+
+from .menu_service import MenuService, load_menu
+
+__all__ = ["MenuService", "load_menu"]

--- a/src/orchestra/knowledge/menu_service.py
+++ b/src/orchestra/knowledge/menu_service.py
@@ -4,9 +4,21 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+from orchestra.interfaces import KnowledgeInterface
+
+
+class MenuService(KnowledgeInterface):
+    """Service for accessing restaurant menu data."""
+
+    def __init__(self) -> None:
+        self._menu_file = Path(__file__).resolve().parent / "menu" / "restaurant_menu.json"
+
+    def load_menu(self) -> Dict[str, Any]:
+        """Load the restaurant menu from the packaged JSON file."""
+        with self._menu_file.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
 
 def load_menu() -> Dict[str, Any]:
-    """Load the restaurant menu from the packaged JSON file."""
-    menu_file = Path(__file__).resolve().parent / "menu" / "restaurant_menu.json"
-    with menu_file.open("r", encoding="utf-8") as f:
-        return json.load(f)
+    """Convenience wrapper to load the menu using the default service."""
+    return MenuService().load_menu()


### PR DESCRIPTION
## Summary
- Add `KnowledgeInterface` to define contract for knowledge layer services
- Implement `MenuService` adhering to interface and provide menu-loading helper
- Expose knowledge utilities from package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc76809ec8323849cb6482c79cb63